### PR TITLE
Fix `_vale.ini` path issues and expand options

### DIFF
--- a/_vale.ini
+++ b/_vale.ini
@@ -1,7 +1,57 @@
-StylesPath = ../Fio-styles
+############################# Core Settings ###################################
 
+# To use: copy this file to the parent directory or where you wish to run Vale
+# from. It can also be placed in your home directory, remember to update
+# StylesPath.
+
+# Where styles live. To add an additional style, such as write-good, put it here.
+# You could also mv a style, such as Fio-docs, into a different directory.
+StylesPath = fio-style
+
+# To use from here, comment out the above path and uncomment the following:
+#StylesPath = ../fio-style
+
+# You can add different terms to either accept or reject by adding them to vocab.
+# This can be useful if you are using a new term or writing to a specific audience.
 #vocab = blog
+
+# "suggestion" is the lowest level, followed by "warning" and "error".
+# Change if you want less noise while reviewing.
 MinAlertLevel = suggestion
 
+# Inline-level HTML tags to ignore.
+#IgnoredScopes =
+
+# HTML classes to ignore.
+#IgnoredClasses =
+
+# Block-level HTML tags to ignore
+#SkippedScopes =
+
+# What is consided to be an individual word.
+#WordTemplate =
+
+################################ Format #######################################
+
+# Associations: Useful for alternative file extension; <alt-name> = <common>.
+[formats]
+mdx = md
+
+
+# Vale supports a lot of markup languages. ReStructuredText and Markdown being
+# what we will usually be using. Different styles can be set for different file
+# formats
 [*.{md,rst}]
+
+# Based on will enable ALL rules that make up the style
 BasedOnStyles = Vale, Fio-docs
+
+# Rules can also be enabled individually:
+#Fio-docs.InclusiveLanguage = YES
+
+# ... or disabled
+#Fio-docs.Contractions = NO
+
+# Severity level can be modified for a rule as well:
+Vale.Spelling = warning
+


### PR DESCRIPTION
StylePath was updated, and comments on additional options was added.
`Vale.Spelling` was set to warning instead of error. This can be changed
once Vocab files are added to.

Ran against markdown files, working as intended.

No specific issue that this commit applies to.

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>