### PR TITLE
Add header capitalization rule

### DIFF
--- a/Fio-docs/Header-cap.yml
+++ b/Fio-docs/Header-cap.yml
@@ -1,0 +1,7 @@
+extends: capitalization
+message: "'%s': Use APA title case: https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case"
+level: error
+scope: heading
+match: $title
+# Regarding Titles, AP and APA fully agree
+style: AP


### PR DESCRIPTION
This extends the capitalization style, which is built into Vale, so it required little work other than adding a message and setting to error.

QA steps taken: checked against temp markdown and rst files, no issues noted.

This addresses Jira #1975
This applies to Jira #1629

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>