### PR TITLE
Add rules for dashes

### DIFF
--- a/Fio-docs/em-dash.yml
+++ b/Fio-docs/em-dash.yml
@@ -1,0 +1,17 @@
+# Rule for em dash: —
+# The em dash is used within a sentence for emphasis in place of other punctation
+# hypen ( - ) and en dash ( – ) should not be used.
+
+extends: existence
+message: "Did you mean to you use an em dash '—'?"
+link: https://foundriesio.atlassian.net/wiki/spaces/ID/pages/2392067/Foundries.io+Style+and+Communication+Guide#Dashes-and-Hyphens
+  #nonword: true
+level: warning
+tokens:
+# Note, while some instances, such as spaces around a hypen, will trigger a warning errounously,
+# the assumption is that in most of these tokens, an em dash is generally what is desired.
+# This is why the rule is set to a warning rather than an error. 
+  - '\b[-–—]\s'
+  - '\s[-–—]\b'
+# excluding en dash, as this may occur when the presence of an en dash is correct
+  - '\s[-—]\s'

--- a/Fio-docs/en-dash.yml
+++ b/Fio-docs/en-dash.yml
@@ -1,0 +1,12 @@
+# Rule for en dash: –
+# The en dash is used to join two numerical values, such as a range or date.
+# hypen ( - ) and em dash ( — ) should not be used.
+
+extends: existence
+message: "Use an en dash for numerical ranges and dates"
+link: https://foundriesio.atlassian.net/wiki/spaces/ID/pages/2392067/Foundries.io+Style+and+Communication+Guide#Dashes-and-Hyphens
+nonword: true
+level: error
+tokens:
+  - '\b\d+\s?[-]\s?\d+\b'
+  - '\b\d+\s[–]\s\d+\b'

--- a/_vale.ini
+++ b/_vale.ini
@@ -6,14 +6,14 @@
 
 # Where styles live. To add an additional style, such as write-good, put it here.
 # You could also mv a style, such as Fio-docs, into a different directory.
-StylesPath = styles
+#StylesPath = styles
 
 # Packages can be just the name if part of the vale package hub, or could be the
 # URL to the release zip
 # Packages = proselint
 
 # To use from here, comment out the above path and uncomment the following:
-#StylesPath = ../fio-style
+StylesPath = ../fio-style
 
 # "suggestion" is the lowest level, followed by "warning" and "error".
 # Change if you want less noise while reviewing.


### PR DESCRIPTION
Rules for Em dashes and en dashes added, with one file for each. The em dash one may prove to be a little too aggressive in matching, and is fairly broad in scope, which we may want to change later. As such, the em dash rule is set as a warning. The en dash should hopefully only be triggered when appropriate. Note the en dash rule currently only covers numerical ranges and dates. The use of en dashes extend past this, however their use between words is more nuanced and will remain something for a copy editor or reviewer to look out for.

QA steps: ran both against a set of misuses written in markdown, with tests meant to trigger and not trigger the linter. The real test will be how these punctuation marks end up being used or misused in content.

This commit addresses Jira FSTK #1980
This commit applies to FSTK #1628

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>