### PR TITLE
Add rule for Oxford comma

### DIFF
--- a/Fio-docs/oxford-comma.yml
+++ b/Fio-docs/oxford-comma.yml
@@ -1,0 +1,10 @@
+# Inspired by example provided in vale documentation, with modifed message, level, and addition
+# to regex token
+extends: existence
+message: "Use the Oxford comma in '%s'."
+link: https://foundriesio.atlassian.net/wiki/spaces/ID/pages/2392067/Foundries.io+Style+and+Communication+Guide#Commas
+scope: sentence
+level: warning
+nonword: true
+tokens:
+  - '(?:[^\s,]+,){1,} \w+ (?:and|or|nor) \w+[.?!]'


### PR DESCRIPTION
Added rule for oxford comma, setting it to warning. In most cases that this matches, we will want to use it, however there are instances where it is correct to avoid, such as with grouping of terms with a conjunction between two terms.

QA Steps: Ran linter rule against each case, triggered only when appropriate.

This commit addresses Jira FFTK #1982
This commit applies to Jira FFTK #1628

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>