### PR TITLE
Add trademark linter rules

### DIFF
--- a/Fio-docs/Arm-trademark.yml
+++ b/Fio-docs/Arm-trademark.yml
@@ -1,0 +1,10 @@
+# Trademark use Arm
+extends: conditional
+message: "'%s' should be marked as a trademark first time it occurs in body of text."
+# While case sensitive "Arm" is unlikely to cause a false positive, not impossible, so setting level
+# as warning rather than error
+level: warning
+scope: sentence
+ignorecase: false
+first: 'Arm'
+second: '(Arm)(?:®|\(R\))'

--- a/Fio-docs/Fioctl-trademark.yml
+++ b/Fio-docs/Fioctl-trademark.yml
@@ -1,0 +1,8 @@
+# Trademark use for Fioctl
+extends: conditional
+message: "'%s' should be marked as a trademark first time it occurs in body of text."
+level: error
+scope: sentence
+ignorecase: false
+first: 'Fioctl'
+second: '(Fioctl)(?:™|\(TM\))'

--- a/Fio-docs/FoundriesFactory-trademark.yml
+++ b/Fio-docs/FoundriesFactory-trademark.yml
@@ -1,0 +1,8 @@
+# Trademark use for FoundriesFactory
+extends: conditional
+message: "'%s' should be marked as a trademark first time it occurs in body of text."
+level: error
+scope: sentence
+ignorecase: false
+first: 'FoundriesFactory'
+second: '(FoundriesFactory)(?:®|\(R\))'

--- a/Fio-docs/Foundriesio-trademark.yml
+++ b/Fio-docs/Foundriesio-trademark.yml
@@ -1,0 +1,8 @@
+# Trademark use for Foundries.io
+extends: conditional
+message: "'%s' should be marked as a trademark first time it occurs in body of text."
+level: error
+scope: sentence
+ignorecase: false
+first: 'Foundries.io'
+second: '(Foundries.io)(?:™|\(TM\))'

--- a/Fio-docs/Linux-trademark.yml
+++ b/Fio-docs/Linux-trademark.yml
@@ -1,0 +1,8 @@
+# Trademark use for Linux.
+extends: conditional
+message: "'%s' should be marked as a trademark first time it occurs in body of text."
+level: error
+scope: sentence
+ignorecase: false
+first: 'Linux'
+second: '(Linux)(?:®|\(R\))'

--- a/Fio-docs/NXP-trademark.yml
+++ b/Fio-docs/NXP-trademark.yml
@@ -1,0 +1,8 @@
+# Trademark use NXP
+extends: conditional
+message: "'%s' should be marked as a trademark first time it occurs in body of text."
+level: error
+scope: sentence
+ignorecase: false
+first: 'NXP'
+second: '(NXP)(?:®|\(R\))'


### PR DESCRIPTION
Small set of trademarks added. Registered trademarks are caught, however "TM" is not being caught, however this may be an encoding issue. Leaving in for the time being, and this will be noted and worked on separately.

For QA steps, basic tests of terms written in markdown added, testing for multiple instances, and across page, section, and paragraph. Working as intended.

This addresses Jira  FFTK #1978
This applies to Jira FFTK #1628

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>