### PR TITLE
Add linter rule for sentence length

### DIFF
--- a/Fio-docs/sentence-length.yml
+++ b/Fio-docs/sentence-length.yml
@@ -1,0 +1,6 @@
+extends: occurrence
+message: "Aim for sentences no longer than 25 words"
+scope: sentence
+level: suggestion
+max: 25
+token: \b(\w+)\b


### PR DESCRIPTION
Added simple rule suggesting sentence length be kept under 25 words.

QA steps: wrote a rather long sentence about a llama, it was suggested I do not do so.

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>