### PR TITLE
Add API to exception list

### DIFF
--- a/Fio-docs/expand-acronyms.yml
+++ b/Fio-docs/expand-acronyms.yml
@@ -41,6 +41,7 @@ exceptions:
 # This rule was tested against the docs for v89 to help identify exceptions.
 
   - AMD
+  - API
   - ARM
   - BSP
   - CI


### PR DESCRIPTION
Added API to the acronym exception list. This wasn't caught due to fio-style having a fuller vocab list, however this makes much more sense to have within the rule.

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>