### PR TITLE
Add additional acronyms to the exceptions list

### DIFF
--- a/Fio-docs/expand-acronyms.yml
+++ b/Fio-docs/expand-acronyms.yml
@@ -43,6 +43,7 @@ exceptions:
   - AMD
   - API
   - ARM
+  - AWS
   - BSP
   - CD
   - CI
@@ -70,6 +71,7 @@ exceptions:
   - SDK
   - SSH
   - SSL
+  - TLS
   - UART
   - UI
   - UX


### PR DESCRIPTION
Additional acronyms have been identified that do not need to be expanded, and added to the exceptions in `expand-acronyms.yml`.

No testing performed.
No issue to link to.

Signed-off-by: Katrina Prosise <katrina.prosise@foundries.io>