### PR TITLE
Update copyright for Fioctl

### DIFF
--- a/Fio-docs/Fioctl-trademark.yml
+++ b/Fio-docs/Fioctl-trademark.yml
@@ -5,4 +5,4 @@ level: error
 scope: sentence
 ignorecase: false
 first: 'Fioctl'
-second: '(Fioctl)(?:™|\(TM\))'
+second: '(Fioctl)(?:®|\(R\))'


### PR DESCRIPTION
Fioctl is now a registered trademark, "tm" has been replaced with "R" for the copyright rule.

No QA to note.

No Jira issues associated.