### PR TITLE
Fixup: em-dash rule

### DIFF
--- a/Fio-docs/em-dash.yml
+++ b/Fio-docs/em-dash.yml
@@ -14,4 +14,4 @@ tokens:
   - '\b[-–—]\s'
   - '\s[-–—]\b'
 # excluding en dash, as this may occur when the presence of an en dash is correct
-  - '\s[-—]\s'
+  - '\s[-–]\s'


### PR DESCRIPTION
A style guide tells to use an em dash as an emphasis inside a sentence. A corresponding rule should deny the use of hyphen or en dash in these places. But, a rule in question was errorneously denying the use of hyphen or em dash.

This little fix was verified when running vale on a text using em dash.