### PR TITLE
Update no-click-here rule for updated vale

### DIFF
--- a/Fio-docs/No-click-here.yml
+++ b/Fio-docs/No-click-here.yml
@@ -1,7 +1,12 @@
 extends: existence
-message: Do not use "click here"
+message: Do not use "click here" type links
 level: error
 ignorecase: true
-scope: link
-tokens:
-  - here  
+scope: raw
+raw:
+  - '\[click here\]'
+  - '\[see here\]'
+  - '\[read here\]'
+  - '\[available here\]'
+    
+


### PR DESCRIPTION
The linter no longer uses the scope "links", instead recommending the use of the "raw" scope, which is implemented in this commit.

Ran updated rule through some casual tests, all seems to work.

No issues to link.