### PR TITLE
Update arm trademark rule

### DIFF
--- a/Fio-docs/Arm-trademark.yml
+++ b/Fio-docs/Arm-trademark.yml
@@ -1,10 +1,10 @@
 # Trademark use Arm
 extends: conditional
-message: "'%s' should be marked as a trademark first time it occurs in body of text."
+message: "'%s' should be marked as a *registered* trademark first time it occurs in body of text."
 # While case sensitive "Arm" is unlikely to cause a false positive, not impossible, so setting level
 # as warning rather than error
 level: warning
 scope: sentence
 ignorecase: false
-first: 'Arm'
+first: 'Arm(\s|[.,\,])'
 second: '(Arm)(?:®|\(R\))'


### PR DESCRIPTION
Improved capture to exclude words which contain Arm* such as Army. Also clarified in message that it is a registered trademark which is expected.