### PR TITLE
Add rule for FoundriesFactory Platform

### DIFF
--- a/Fio-docs/FoundriesFactory-adjective.yml
+++ b/Fio-docs/FoundriesFactory-adjective.yml
@@ -1,0 +1,8 @@
+extends: conditional
+message: "When used with trademark, FoundriesFactory must be an adjective, followed by Platform, Saas, Service, Software, or Solution"
+level: warning
+scope: text
+ignorecase: false
+first: 'FoundriesFactory™'
+second: '(FoundriesFactory™)+ ((Platform)|(SaaS)|(Service)|(Software)|(Solution))' 
+


### PR DESCRIPTION
FoundriesFactory, when used with a trademark, is an adjective, and is used to denote the product, and should be followed by Platform, SaaS, Service, Software, or Solution. Rule was created to check for this.

QA: Ran against example, works as intended.

This commit addresses FFTK-3430