### PR TITLE
Add replacements for common edits

### DIFF
--- a/Fio-docs/help-not-ensure.yml
+++ b/Fio-docs/help-not-ensure.yml
@@ -1,0 +1,8 @@
+extends: substitution
+message: Consider '%s' instead of '%s'
+level: suggestion
+ignorecase: true
+# The array is 'observed: expected' pairs
+swap:
+  ensure: help
+  ensures: helps

--- a/Fio-docs/no-lifespan.yml
+++ b/Fio-docs/no-lifespan.yml
@@ -1,0 +1,7 @@
+extends: substitution
+message: Consider '%s' instead of '%s'
+level: suggestion
+ignorecase: true
+# The array is 'observed: expected' pairs
+swap:
+  lifespan: post-release

--- a/Fio-docs/security-focused.yml
+++ b/Fio-docs/security-focused.yml
@@ -1,0 +1,11 @@
+# Calling things "Secure" can be tricky, and definitive/absolute statements on security should be avoided.
+extends: substitution
+message: Consider '%s' instead of '%s'
+link: https://foundriesio.atlassian.net/wiki/spaces/ID/pages/2392067/Foundries.io+Style+and+Communication+Guide#Statements-on-Security
+level: suggestion
+ignorecase: true
+# The array is 'observed: expected' pairs
+swap:
+  secured software: security focused software
+  secure update: security focused update
+  securing: protecting


### PR DESCRIPTION
Added suggestion rules for some common edits as requested by marketing. While some common edits are too context specific for writing a rule, the ones that could be implemented without complex scripting were.

Note that these are suggestions; exceptions may apply.

QA Steps: ran rules against a Markdown to ensure they were triggered.

This commit addresses FFTK-3450