### PR TITLE
Add rule to check for extra spaces

### DIFF
--- a/Fio-docs/extra-spaces.yml
+++ b/Fio-docs/extra-spaces.yml
@@ -1,0 +1,6 @@
+extends: existence
+message: "Use only one space"
+level: warning
+nonword: true
+tokens:
+  - '[\w.?!,\(\)\-":] {2,}[\w.?!,\(\)\-":]'


### PR DESCRIPTION
Checks for extra spaces between words and sentences.

Tested against Markdown file containing the trigger for the warning. Worked as intended.

This commit addresses Jira FFTK-2040: Linter rule to catch extra spaces