### PR TITLE
Add rule for target

### DIFF
--- a/Fio-docs/Branding-and-names.yml
+++ b/Fio-docs/Branding-and-names.yml
@@ -30,6 +30,7 @@ swap:
   fioctl: Fioctl
   arduino: Arduino
   nxp: NXP
+  target: Target
   'aktualizr(?:-| )lite': aktualizr-lite
   exceptions:
     '?:+.py'


### PR DESCRIPTION
In the majority of cases, "Target" should be used over "target". Added to other capitalization rules for names, and will trigger a suggestion.

QA: checked rule, works as intended.

This commit addresses Jira issue FFTK-1701, "…rule for expecting Target…"